### PR TITLE
Updated the AbstractRequest to allow negative amounts so that discounts can be applied

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -13,6 +13,8 @@ abstract class AbstractRequest extends BaseAbstractRequest
     protected $liveEndpoint = 'https://api.zipmoney.com.au/merchant/v1';
     protected $testEndpoint = 'https://api.sandbox.zipmoney.com.au/merchant/v1';
 
+    protected $negativeAmountAllowed = true;
+
     public function getKey()
     {
         return $this->getParameter('key');


### PR DESCRIPTION
Not sure if you would prefer this to be in the AbstractRequest or set only for specific requests, but Zip Pay requires discounts to be provided with a negative amount which will fail if negative amounts are not allowed.