### PR TITLE
Updated item prices so that they are no longer multiplied by the quantity

### DIFF
--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -143,7 +143,7 @@ class RestAuthorizeRequest extends AbstractRequest
     {
         return [
             'name' => $item->getName(),
-            'amount' => $item->getQuantity() * $this->formatCurrency($item->getPrice()),
+            'amount' => $this->formatCurrency($item->getPrice()),
             'quantity' => $item->getQuantity(),
             'type' => $item instanceof ItemTypeInterface ? $item->getType() : 'sku',
             'reference' => $item->getReference(),


### PR DESCRIPTION
It seems that the `amount` field for an item is being calculated incorrectly when a quantity greater than one is supplied.

I have double checked the documentation at [https://zip-online.api-docs.io/v1/api-specification/create-a-checkout](https://zip-online.api-docs.io/v1/api-specification/create-a-checkout) and it states the following for the `order.items[].amount` field:

> Amount of the item. Sum of item amounts, each multiplied by its quantity (next field) must equal amount on the order. Integer or number to 2.dp (eg; 100.00 or 100)

Zip could probably do with updating their documentation to make that a bit clearer.