### PR TITLE
Added an optional shipping address into the data for a RestAuthorizeRequest

### DIFF
--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -77,9 +77,14 @@ class RestAuthorizeRequest extends AbstractRequest
         return !empty($this->getMeta());
     }
 
-    public function hasShippingAddress()
+    public function getHasShippingAddress()
     {
-        return !empty($this->getShippingAddressLine1());
+        return $this->getParameter('hasShippingAddress');
+    }
+
+    public function setHasShippingAddress($value)
+    {
+        return $this->setParameter('hasShippingAddress', $value);
     }
 
     public function getData()
@@ -161,9 +166,9 @@ class RestAuthorizeRequest extends AbstractRequest
         $shippingDetails = [
             'pickup' => true,
         ];
-        // Check for a shipping address and set pickup to `false` and add the address
-        // details if one has been supplied.
-        if ($this->hasShippingAddress()) {
+        // Check if a shipping address has supposedly been supplied and, if so, set pickup
+        // to `false` and add the address details.
+        if ($this->getHasShippingAddress()) {
             $shippingDetails = [
                 'pickup' => false,
                 'address' => [

--- a/src/Message/RestAuthorizeRequest.php
+++ b/src/Message/RestAuthorizeRequest.php
@@ -77,6 +77,11 @@ class RestAuthorizeRequest extends AbstractRequest
         return !empty($this->getMeta());
     }
 
+    public function hasShippingAddress()
+    {
+        return !empty($this->getShippingAddressLine1());
+    }
+
     public function getData()
     {
         $this->validate(
@@ -153,9 +158,25 @@ class RestAuthorizeRequest extends AbstractRequest
 
     public function getOrderShippingDetails()
     {
-        return [
+        $shippingDetails = [
             'pickup' => true,
         ];
+        // Check for a shipping address and set pickup to `false` and add the address
+        // details if one has been supplied.
+        if ($this->hasShippingAddress()) {
+            $shippingDetails = [
+                'pickup' => false,
+                'address' => [
+                    'line1' => $this->getShippingAddressLine1(),
+                    'line2' => $this->getShippingAddressLine2(),
+                    'city' => $this->getShippingAddressCity(),
+                    'state' => $this->getShippingAddressState(),
+                    'postal_code' => $this->getShippingAddressPostalCode(),
+                    'country' => $this->getShippingAddressCountry(),
+                ],
+            ];
+        }
+        return $shippingDetails;
     }
 
     public function getConfig()
@@ -203,6 +224,36 @@ class RestAuthorizeRequest extends AbstractRequest
     public function getBillingAddressLastName()
     {
         return $this->getCard()->getBillingLastName();
+    }
+
+    public function getShippingAddressLine1()
+    {
+        return $this->getCard()->getShippingAddress1();
+    }
+
+    public function getShippingAddressLine2()
+    {
+        return $this->getCard()->getShippingAddress2();
+    }
+
+    public function getShippingAddressCity()
+    {
+        return $this->getCard()->getShippingCity();
+    }
+
+    public function getShippingAddressState()
+    {
+        return $this->getCard()->getShippingState();
+    }
+
+    public function getShippingAddressPostalCode()
+    {
+        return $this->getCard()->getShippingPostcode();
+    }
+
+    public function getShippingAddressCountry()
+    {
+        return $this->getCard()->getShippingCountry();
     }
 
     protected function createResponse($data, $headers = [], $status = 404)


### PR DESCRIPTION
This pull request adds support for handling a shipping address in a RestAuthorizeRequest, but I am not certain if the way that it determines if a shipping address has been supplied is entirely suitable.

What would be the preferred way to determine whether or not to include the shipping address? Currently I have just implemented the following:
```
    public function hasShippingAddress()
    {
        return !empty($this->getShippingAddressLine1());
    }
```